### PR TITLE
Update nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -138,10 +138,11 @@ in rec {
         '';
 
         nativeBuildInputs = with pkgs; [
-          colmena
           act
+          sops
           # nixel
-          nixfmt-rfc-style
+          alejandra
+          colmena
           npins
         ];
       };


### PR DESCRIPTION
Removed 'nixfmt-rfc-style' from nix-shell and added 'sops' and 'alejandra'.