### PR TITLE
chore: cleanup + use kittenLib.network

### DIFF
--- a/lib/network/default.nix
+++ b/lib/network/default.nix
@@ -1,4 +1,4 @@
-{lib, ...}: let
+args @ {lib, ...}: let
   isValidIPv4 = ip: let
     parts = lib.splitString "." ip;
     isByte = part: let
@@ -64,9 +64,9 @@
 
       val =
         if newLen == 8
-        then "${prefix}:${x}/${builtins.toString (getCidr self)}"
+        then "${prefix}:${x}"
         else if newLen < 8 && newLen > 0
-        then "${prefix}::${longX}/${builtins.toString (getCidr self)}"
+        then "${prefix}::${longX}"
         else throw "cannot add ${x} to ${prefix} -> invalid IPv6 ${prefix}::${x}/${builtins.toString (getCidr self)}";
     in
       lib.throwIf (
@@ -81,47 +81,36 @@
           __toString = getCleanPrefix;
 
           len = lib.toInt (getCidr args);
+          addWithCIDR = x: "${appendToPrefix args x}/${getCidr args}";
+          addIntWithCIDR = i: "${appendToPrefix args (lib.toHexString i)}/${getCidr args}";
           add = x: appendToPrefix args x;
+          addInt = i: appendToPrefix args (lib.toHexString i);
         }
         // args
       else if builtins.isString args
       then withCIDR {net = args;}
       else throw "withCIDR needs a net argument";
-in rec {
+
+  params = import ./params.nix (args // {inherit withCIDR;});
+in {
   inherit isValidIPv4 isValidIPv6;
+  inherit (params) internal6;
 
-  internal6 = withCIDR {
-    asn = 4242421945;
-    net = "1010::/16";
+  pretty = let
+    forbiddenEntries = [
+      "__toString"
 
-    cafe = withCIDR {
-      net = "${internal6}:cafe::/32";
+      "add"
+      "addInt"
 
-      customers = "${internal6.cafe}:fffe";
-      kittens = withCIDR {
-        net = "${internal6.cafe}:ffff::/48";
-
-        loopbacks = withCIDR {
-          net = "${internal6.cafe.kittens}:fefe::/64";
-
-          internet = "${internal6.cafe.kittens.loopbacks}::b00b";
-
-          vultr = "${internal6.cafe.kittens.loopbacks}::b48d";
-
-          ig1-kit-rtr = "${internal6.cafe.kittens.loopbacks}::113:25";
-          ig1-kit-rr = "${internal6.cafe.kittens.loopbacks}::113:91";
-        };
-
-        underlay = withCIDR {
-          net = "${internal6.cafe.kittens}:feff::/64";
-
-          routed = withCIDR {
-            net = "${internal6.cafe.kittens.underlay}:b00b::/80";
-
-            iguane = withCIDR "1010:cafe:ffff:feff:b00b:3965:113:0/112";
-          };
-        };
-      };
-    };
-  };
+      "addWithCIDR"
+      "addIntWithCIDR"
+    ];
+  in
+    lib.filterAttrsRecursive (
+      path: _:
+        !(builtins.isString path && builtins.elem path forbiddenEntries)
+        && !(builtins.isList path && builtins.elem (builtins.elemAt path ((builtins.length path) - 1)) forbiddenEntries)
+    )
+    params;
 }

--- a/lib/network/params.nix
+++ b/lib/network/params.nix
@@ -1,0 +1,37 @@
+{withCIDR, ...}: rec {
+  internal6 = withCIDR {
+    asn = 4242421945;
+    net = "1010::/16";
+
+    cafe = withCIDR {
+      net = "${internal6}:cafe::/32";
+
+      customers = withCIDR "${internal6.cafe}:fffe::/48";
+      kittens = withCIDR {
+        net = "${internal6.cafe}:ffff::/48";
+
+        loopbacks = withCIDR {
+          net = "${internal6.cafe.kittens}:fefe::/64";
+
+          internet = "${internal6.cafe.kittens.loopbacks}::b00b";
+
+          vultr = "${internal6.cafe.kittens.loopbacks}::b48d";
+
+          ig1-kit-rtr = "${internal6.cafe.kittens.loopbacks}::113:25";
+          ig1-kit-rr = "${internal6.cafe.kittens.loopbacks}::113:91";
+        };
+
+        underlay = withCIDR {
+          net = "${internal6.cafe.kittens}:feff::/64";
+
+          routed = withCIDR {
+            net = "${internal6.cafe.kittens.underlay}:b00b::/80";
+
+            iguane = withCIDR "${internal6.cafe.kittens.underlay.routed}:3965:113:0/112";
+            aure = withCIDR "${internal6.cafe.kittens.underlay.routed}:caca:b173:0/112";
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/system/kitten/connect/bird2/snippets/functions.nix
+++ b/modules/system/kitten/connect/bird2/snippets/functions.nix
@@ -1,4 +1,4 @@
-{...}: {
+{kittenLib, ...}: {
   kittenModules.bird.extraConfigs."common/functions.conf" = {
     order = 05;
 
@@ -12,20 +12,18 @@
 
       function is_valid6_network() {
           return net ~ [
-            2a12:5844:1310::/44,
-            1010:cafe:ffff::/48{48,64},
-            1010:cafe:ffff:fefe::/64{128,128},
-            1010:cafe:ffff:feff::/64{112,112}
+            ${kittenLib.network.internal6.cafe.kittens.net}{48,64},
+            ${kittenLib.network.internal6.cafe.kittens.loopbacks.net}{128,128},
+            ${kittenLib.network.internal6.cafe.kittens.underlay.net}{112,112},
+            2a12:5844:1310::/44
           ];
       }
 
       function is_rr_valid6_network() {
           return net ~ [
-            2a12:5844:1310::/44,
-            # 1010:cafe:ffff:fefe::/64{128,128},
-            # 1010:cafe:ffff:feff::/64{112,112},
-            1010:cafe:ffff::/48{48,64},
-            1010:cafe:fffe::/48{56,56}
+            ${kittenLib.network.internal6.cafe.kittens.net}{48,64},
+            ${kittenLib.network.internal6.cafe.customers.net}{56,56},
+            2a12:5844:1310::/44
           ];
       }
     '';

--- a/modules/system/kitten/connect/firewall/profiles/homerouters.nix
+++ b/modules/system/kitten/connect/firewall/profiles/homerouters.nix
@@ -1,5 +1,6 @@
 args @ {
   lib,
+  kittenLib,
   config,
   wgpeers,
   ...
@@ -8,7 +9,7 @@ args @ {
   inherit (lib.strings) removeSuffix;
   # inherit (lib.attrsets) filterAttrs attrNames;
 
-  fileName = baseNameOf (__curPos).file; # (__curPos) or (unsafeGetAttrPos "args" { inherit args; })
+  fileName = baseNameOf __curPos.file; # (__curPos) or (unsafeGetAttrPos "args" { inherit args; })
   profileName = lib.strings.removeSuffix ".nix" fileName;
 
   cfg = config.kittenModules.firewall;

--- a/systems/clients/NIXP/network-configuration.nix
+++ b/systems/clients/NIXP/network-configuration.nix
@@ -1,4 +1,4 @@
-{...}: {
+{kittenLib, ...}: {
   networking = {
     #nameservers = [ "1.3.3.7" ];
 
@@ -6,42 +6,23 @@
       ens18.useDHCP = true;
 
       ens19 = {
-        # ipv4.addresses = [
-        #   {
-        #     address = "185.10.17.209";
-        #     prefixLength = 24;
-        #   }
-        # ];
-
         ipv6 = {
           routes = [
             {
               address = "2a13:79c0:ff00::";
               prefixLength = 40;
-              via = "1010:cafe:ffff:feff:b00b:caca:b173:25";
+              via = "${kittenLib.network.internal6.cafe.kittens.underlay.routed.aure}:25";
             }
           ];
           addresses = [
             {
-              address = "1010:cafe:ffff:feff:b00b:caca:b173:96";
+              address = "${kittenLib.network.internal6.cafe.kittens.underlay.routed.aure}:96";
               prefixLength = 112;
             }
           ];
         };
       };
     };
-
-    # defaultGateway = {
-    #   address = "185.10.17.254";
-    #   metric = 42;
-    #   interface = iface;
-    # };
-
-    # defaultGateway6 = {
-    #   address = "1010:cafe:ffff:feff:b00b:3965:113:25";
-    #   metric = 42;
-    #   interface = kittenIFACE;
-    # };
 
     useDHCP = false;
     useNetworkd = true;

--- a/systems/homerouters/aure-home-kitrtr/default.nix
+++ b/systems/homerouters/aure-home-kitrtr/default.nix
@@ -55,22 +55,14 @@ in {
 
     loopback0 = {
       enable = true;
-      ipv6 = ["1010:cafe:ffff:fefe::22f0"];
     };
 
     bird = {
       enable = true;
-      loopback6 = "1010:cafe:ffff:fefe::22f0";
+      loopback6 = kittenLib.network.internal6.cafe.kittens.loopbacks.add "22f0";
 
       static6 = [
-        "::/0 recursive 1010:cafe:ffff:fefe::b00b"
-
-        # "1010:cafe:ffff:feff:b00b:caca:b173:0/112 unreachable" # Direct on ens19
-        # "2a13:79c0:fffe:100::/56 unreachable"
-
-        #"2a13:79c0:ffff::/48 unreachable" # Networking stuff
-        #"1010:cafe:ffff:fefe::/64 unreachable" # LoopBacks
-        #"2a12:5844:1310::/44 unreachable" # full range /40
+        "::/0 recursive ${kittenLib.network.internal6.cafe.kittens.loopbacks.internet}"
       ];
 
       peers = peers.bird;
@@ -86,7 +78,7 @@ in {
       forward = {
         enable = true;
         rules = ''
-          iifname "${kittenIFACE}" ip6 saddr 1010:cafe:ffff:feff:b00b:caca:b173:0/112 oifname $wireguardIFACEs counter accept
+          iifname "${kittenIFACE}" ip6 saddr ${kittenLib.network.internal6.cafe.kittens.underlay.routed.aure.net} oifname $wireguardIFACEs counter accept
 
           ct state vmap {
             established : accept,

--- a/systems/homerouters/aure-home-kitrtr/network-configuration.nix
+++ b/systems/homerouters/aure-home-kitrtr/network-configuration.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   iface = "ens18";
   kittenIFACE = "ens19";
 in {
@@ -20,7 +20,7 @@ in {
 
         ipv6.addresses = [
           {
-            address = "1010:cafe:ffff:feff:b00b:caca:b173:25";
+            address = "${kittenLib.network.internal6.cafe.kittens.underlay.routed.aure}:25";
             prefixLength = 112;
           }
         ];

--- a/systems/homerouters/aure-home-kitrtr/peers/KIT-IG1-RTR.nix
+++ b/systems/homerouters/aure-home-kitrtr/peers/KIT-IG1-RTR.nix
@@ -1,12 +1,12 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;
-  peerIP = "1010:cafe:ffff:feff::53";
+  peerIP = kittenLib.network.internal6.cafe.kittens.underlay.add "53";
   localAS = kittenASN;
 
   wireguard = {
-    address = "1010:cafe:ffff:feff::52";
+    address = kittenLib.network.internal6.cafe.kittens.underlay.add "52";
     # port = 51842;
     endpoint = "78.40.121.76:51842";
     peerKey = "gDriA5mhKKh44OHEIxmmevphoVRLK45TRJmFS1DV1i4=";

--- a/systems/homerouters/firewall.nix
+++ b/systems/homerouters/firewall.nix
@@ -3,6 +3,7 @@
 # https://search.nixos.org/options and in the NixOS manual (`nixos-help`).
 {
   lib,
+  kittenLib,
   pkgs,
   targetConfig,
   birdConfig,
@@ -19,8 +20,8 @@
     then birdConfig.transitNetworks
     else [
       "2a12:5844:1310::/44" # Transits Customer ranges: 2a12:5844:131{0-f}::/48
-      "1010:cafe:ffff:fefe::/64"
-      "1010:cafe:ffff:feff:b00b::/80"
+      kittenLib.network.internal6.cafe.kittens.loopbacks.net
+      kittenLib.network.internal6.cafe.kittens.underlay.routed.net
     ];
   # wgPeers = filterAttrs (n: v: v ? wireguard && v.wireguard != { }) birdConfig.peers;
 
@@ -96,15 +97,6 @@ in {
               ${optionalString (
                 wgPeers != {}
               ) "iifname $wireguardIFACEs oifname $wireguardIFACEs counter accept"}
-
-              # ip6 daddr 2a12:5844:1310::/44 counter accept
-              # ip6 daddr { 1010:cafe:ffff:feff:b00b:3945:a51:b00b, 1010:cafe:ffff:feff:b00b:3945:a51:dead } counter accept
-
-              # ip6 daddr 1010:cafe:ffff:fefe::113:91 tcp dport { 179, 1790 } counter accept
-
-              # ip6 saddr 1010:cafe:ffff:feff:b00b::/80 ip6 daddr 1010:cafe:ffff:fefe::/64 counter accept
-
-              # ip6 saddr { 1010:cafe:ffff:fefe::/64, 1010:cafe:ffff:feff::/64 } ip6 daddr { 1010:cafe:ffff:fefe::/64, 1010:cafe:ffff:feff::/64 } counter accept
             ''
           ]
           ++ optional (birdConfig ? extraForwardRules) birdConfig.extraForwardRules

--- a/systems/homerouters/romain-home-kitrtr/default.nix
+++ b/systems/homerouters/romain-home-kitrtr/default.nix
@@ -72,7 +72,7 @@ in {
 
     bird = {
       enable = true;
-      loopback6 = "1010:cafe:ffff:fefe::2:256";
+      loopback6 = kittenLib.network.internal6.cafe.kittens.loopbacks.add "2:256";
 
       peers = peers.bird;
     };

--- a/systems/homerouters/romain-home-kitrtr/network-configuration.nix
+++ b/systems/homerouters/romain-home-kitrtr/network-configuration.nix
@@ -1,4 +1,4 @@
-{...}: {
+{kittenLib, ...}: {
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
   # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.

--- a/systems/homerouters/romain-home-kitrtr/peers/KIT-IG1-RTR.nix
+++ b/systems/homerouters/romain-home-kitrtr/peers/KIT-IG1-RTR.nix
@@ -1,12 +1,16 @@
-{lib, ...}: let
+{
+  lib,
+  kittenLib,
+  ...
+}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;
-  peerIP = "1010:cafe:ffff:feff::114";
+  peerIP = kittenLib.network.internal6.cafe.kittens.underlay.add "114";
   localAS = kittenASN;
 
   wireguard = {
-    address = "1010:cafe:ffff:feff::115";
+    address = kittenLib.network.internal6.cafe.kittens.underlay.add "115";
     # port = 51842;
     endpoint = "78.40.121.76:51821";
     peerKey = "gDriA5mhKKh44OHEIxmmevphoVRLK45TRJmFS1DV1i4=";

--- a/systems/homerouters/toinux-home-kitrtr/default.nix
+++ b/systems/homerouters/toinux-home-kitrtr/default.nix
@@ -44,19 +44,16 @@ in {
       forward = {
         enable = true;
         # stateless = true;
-        rules = ''
-          # iifname $wireguardIFACEs oifname "vlan36" ip6 daddr 1010:cafe:ffff:feff:b00b:3615:1:0/112 counter accept
-          # oifname $wireguardIFACEs iifname "vlan36" ip6 saddr 1010:cafe:ffff:feff:b00b:3615:1:0/112 counter accept
-        '';
+        # rules = '' ... '';
       };
     };
 
     bird = {
       enable = true;
-      loopback6 = "1010:cafe:ffff:fefe::69:25";
+      loopback6 = kittenLib.network.internal6.cafe.kittens.loopbacks.add "69:25";
 
       static6 = [
-        "::/0 recursive 1010:cafe:ffff:fefe::b00b"
+        "::/0 recursive ${kittenLib.network.internal6.cafe.kittens.loopbacks.internet}"
       ];
 
       peers = peers.bird;

--- a/systems/homerouters/toinux-home-kitrtr/network-configuration.nix
+++ b/systems/homerouters/toinux-home-kitrtr/network-configuration.nix
@@ -1,4 +1,4 @@
-{...}: {
+{kittenLib, ...}: {
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
   # networking.networkmanager.enable = true;  # Easiest to use and most distros use this by default.

--- a/systems/miscservers/aure-kit-bots-01/default.nix
+++ b/systems/miscservers/aure-kit-bots-01/default.nix
@@ -5,6 +5,7 @@
   name,
   nodes,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: let
@@ -43,18 +44,6 @@ in {
       profile = diskoProfile;
       ${diskoProfile} = diskoConfig;
     };
-
-    # firewall = {
-    #   enable = true;
-    #   forward = {
-    #     enable = true;
-    #     # stateless = true;
-    #     rules = ''
-    #       iifname $wireguardIFACEs oifname "vlan36" ip6 daddr 1010:cafe:ffff:feff:b00b:3615:1:0/112 counter accept
-    #       oifname $wireguardIFACEs iifname "vlan36" ip6 saddr 1010:cafe:ffff:feff:b00b:3615:1:0/112 counter accept
-    #     '';
-    #   };
-    # };
   };
   systemd.network.enable = true;
 

--- a/systems/postgres/kit-postgresql-nte/default.nix
+++ b/systems/postgres/kit-postgresql-nte/default.nix
@@ -5,6 +5,7 @@
   name,
   nodes,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: let

--- a/systems/postgres/kit-postgresql-nte/network-configuration.nix
+++ b/systems/postgres/kit-postgresql-nte/network-configuration.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenIface = "ens18";
 in {
   networking = {

--- a/systems/routereflectors/iguane-kit-rr91/default.nix
+++ b/systems/routereflectors/iguane-kit-rr91/default.nix
@@ -4,6 +4,7 @@
 {
   config,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: let
@@ -51,7 +52,9 @@ in
       loopback0 = {
         # Enabled by bird by default
         enable = true;
-        ipv6 = ["1010:cafe:ffff:fefe::113:91"];
+        ipv6 = [
+          (kittenLib.network.internal6.cafe.kittens.loopbacks.add "113:91")
+        ];
       };
     };
 

--- a/systems/routereflectors/iguane-kit-rr91/network-configuration.nix
+++ b/systems/routereflectors/iguane-kit-rr91/network-configuration.nix
@@ -1,6 +1,8 @@
-{...}: let
+{kittenLib, ...}: let
   iface = "ens18";
   kittenIFACE = "ens19";
+
+  myRange = kittenLib.network.internal6.cafe.kittens.underlay.routed.iguane;
 in {
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
@@ -20,7 +22,7 @@ in {
 
         ipv6.addresses = [
           {
-            address = "1010:cafe:ffff:feff:b00b:3965:113:91";
+            address = "${myRange}:91";
             prefixLength = 112;
           }
         ];
@@ -28,7 +30,7 @@ in {
     };
 
     defaultGateway6 = {
-      address = "1010:cafe:ffff:feff:b00b:3965:113:25";
+      address = "${myRange}:25";
       metric = 42;
       interface = kittenIFACE;
     };

--- a/systems/routereflectors/profile.nix
+++ b/systems/routereflectors/profile.nix
@@ -4,6 +4,7 @@
 {
   config,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: {
@@ -35,13 +36,13 @@
         {
           config = {
             peer-group = "kitten";
-            prefix = "1010:cafe:ffff:fefe::/64";
+            prefix = kittenLib.network.internal6.cafe.kittens.loopbacks.net;
           };
         }
         {
           config = {
             peer-group = "kittevpn";
-            prefix = "1010:cafe:ffff:feff::/64";
+            prefix = kittenLib.network.internal6.cafe.kittens.loopbacks.net;
           };
         }
       ];
@@ -49,7 +50,7 @@
         config = {
           as = 4242421945;
           local-address-list = [
-            "1010:cafe:ffff:fefe::113:91"
+            kittenLib.network.internal6.cafe.kittens.loopbacks.ig1-kit-rr
             # "172.23.193.197"
           ];
           router-id = "172.23.193.197";

--- a/systems/routers/firewall.nix
+++ b/systems/routers/firewall.nix
@@ -3,6 +3,7 @@
 # https://search.nixos.org/options and in the NixOS manual (`nixos-help`).
 {
   lib,
+  kittenLib,
   pkgs,
   targetConfig,
   birdConfig,
@@ -18,8 +19,8 @@
     then birdConfig.transitNetworks
     else [
       "2a12:5844:1310::/44" # Transits Customer ranges: 2a12:5844:131{0-f}::/48
-      "1010:cafe:ffff:fefe::/64"
-      "1010:cafe:ffff:feff:b00b::/80"
+      kittenLib.network.internal6.cafe.kittens.loopbacks.net
+      kittenLib.network.internal6.cafe.kittens.underlay.routed.net
     ];
 
   wgPeers = filterAttrs (n: v: v ? wireguard && v.wireguard != {}) birdConfig.peers;

--- a/systems/routers/iguane-kit-rtr/default.nix
+++ b/systems/routers/iguane-kit-rtr/default.nix
@@ -64,23 +64,14 @@ in {
       ${diskoProfile} = diskoConfig;
     };
 
-    # loopback0 = {
-    #   enable = true;
-    #   ipv6 = [ "1010:cafe:ffff:fefe::22f0" ];
-    # };
-
     bird = {
       enable = true;
-      loopback6 = "1010:cafe:ffff:fefe::113:25";
+      loopback6 = kittenLib.network.internal6.cafe.kittens.loopbacks.ig1-kit-rtr;
 
       static6 = [
-        "::/0 recursive 1010:cafe:ffff:fefe::b00b"
+        "::/0 recursive ${kittenLib.network.internal6.cafe.kittens.loopbacks.internet}"
 
-        "1010:cafe:ffff:fefe::113:91/128 via 1010:cafe:ffff:feff:b00b:3965:113:91" # Announce RouteReflector LoopBack
-
-        #"2a13:79c0:ffff::/48 unreachable" # Networking stuff
-        #"1010:cafe:ffff:fefe::/64 unreachable" # LoopBacks
-        #"2a12:5844:1310::/44 unreachable" # full range /40
+        "${kittenLib.network.internal6.cafe.kittens.loopbacks.ig1-kit-rr}/128 via ${kittenLib.network.internal6.cafe.kittens.underlay.routed.iguane}:91 # Announce RouteReflector LoopBack"
       ];
 
       peers = peers.bird;
@@ -98,7 +89,7 @@ in {
         keepInvalidState = true;
         rules = ''
           # iifname "''${kittenIFACE}" ip6 saddr 1010:cafe:ffff:feff:b00b:caca:b173:0/112 oifname $wireguardIFACEs counter accept
-          iifname $wireguardIFACEs ip6 daddr 1010:cafe:ffff:fefe::113:91 tcp dport { 179, 1790 } counter accept
+          iifname $wireguardIFACEs ip6 daddr ${kittenLib.network.internal6.cafe.kittens.loopbacks.ig1-kit-rr} tcp dport { 179, 1790 } counter accept
           oifname bootstrap ip6 daddr 1010:cafe:ffff:feff:b00b:3965:222:0/112 counter accept
 
           # ip6 saddr 2a01:cb08:bbb:3700::/64 oifname ens19 counter accept

--- a/systems/routers/iguane-kit-rtr/network-configuration.nix
+++ b/systems/routers/iguane-kit-rtr/network-configuration.nix
@@ -1,4 +1,8 @@
-{lib, ...}: let
+{
+  lib,
+  kittenLib,
+  ...
+}: let
   iface = "ens18";
   kittenIFACE = "ens19";
 in {
@@ -39,7 +43,7 @@ in {
 
         ipv6.addresses = [
           {
-            address = "1010:cafe:ffff:feff:b00b:3965:113:25";
+            address = "${kittenLib.network.internal6.cafe.kittens.underlay.routed.iguane}:25";
             prefixLength = 112;
           }
         ];

--- a/systems/routers/iguane-kit-rtr/peers/KIT-VIRTUA-EDGE.nix
+++ b/systems/routers/iguane-kit-rtr/peers/KIT-VIRTUA-EDGE.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/iguane-kit-rtr/peers/KIT-VULTR-EDGE.nix
+++ b/systems/routers/iguane-kit-rtr/peers/KIT-VULTR-EDGE.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/iguane-kit-rtr/peers/KIT-aurelien-RBR.nix
+++ b/systems/routers/iguane-kit-rtr/peers/KIT-aurelien-RBR.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/iguane-kit-rtr/peers/KIT-roumain-PAR.nix
+++ b/systems/routers/iguane-kit-rtr/peers/KIT-roumain-PAR.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/iguane-kit-rtr/peers/KIT-toinux-MEL1.nix
+++ b/systems/routers/iguane-kit-rtr/peers/KIT-toinux-MEL1.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
   toinuxASN = 4242423692;
 in {

--- a/systems/routers/virtua-kit-edge/default.nix
+++ b/systems/routers/virtua-kit-edge/default.nix
@@ -58,22 +58,14 @@ in {
       ${diskoProfile} = diskoConfig;
     };
 
-    # loopback0 = {
-    #   enable = true;
-    #   ipv6 = [ "1010:cafe:ffff:fefe::12:10" ];
-    # };
-
     bird = {
       enable = true;
 
-      loopback6 = "1010:cafe:ffff:fefe::12:10";
+      loopback6 = kittenLib.network.internal6.cafe.kittens.loopbacks.add "12:10";
 
       static6 = [
-        # "::/0 recursive 1010:cafe:ffff:fefe::b00b"
-        # ''2a0d:e680:0::b:1/128 via "enp1s0"'' # Vultr bgp neighbor
-        "1010:cafe:ffff:fefe::b00b/128 unreachable"
+        "${kittenLib.network.internal6.cafe.kittens.loopbacks.internet}/128 unreachable"
         #"2a13:79c0:ffff::/48 unreachable" # Networking stuff
-        #"1010:cafe:ffff:fefe::/64 unreachable" # LoopBacks
         "2a12:5844:1310::/44 unreachable" # full range /40
       ];
 
@@ -90,15 +82,7 @@ in {
       forward = {
         enable = true;
         keepInvalidState = true;
-        # rules = ''
-        #   # iifname "''${kittenIFACE}" ip6 saddr 1010:cafe:ffff:feff:b00b:caca:b173:0/112 oifname $wireguardIFACEs counter accept
-        #   iifname $wireguardIFACEs ip6 daddr 1010:cafe:ffff:fefe::113:91 tcp dport { 179, 1790 } counter accept
-        #   oifname bootstrap ip6 daddr 1010:cafe:ffff:feff:b00b:3965:222:0/112 counter accept
-
-        #   ip6 saddr 2a01:cb08:bbb:3700::/64 oifname ens19 counter accept
-
-        #   iifname ens19 oifname $wireguardIFACEs counter accept
-        # '';
+        # rules = '' ... '';
       };
     };
   };

--- a/systems/routers/virtua-kit-edge/peers/KIT-IG1-RTR.nix
+++ b/systems/routers/virtua-kit-edge/peers/KIT-IG1-RTR.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/virtua-kit-edge/peers/KIT-VIRTUA-EDGE.legacy.nix
+++ b/systems/routers/virtua-kit-edge/peers/KIT-VIRTUA-EDGE.legacy.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   # vultr6

--- a/systems/routers/virtua-kit-edge/peers/KIT-vultr-edge.nix
+++ b/systems/routers/virtua-kit-edge/peers/KIT-vultr-edge.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/vultr-kit-edge/default.nix
+++ b/systems/routers/vultr-kit-edge/default.nix
@@ -95,23 +95,17 @@ in {
       ${diskoProfile} = diskoConfig;
     };
 
-    # loopback0 = {
-    #   enable = true;
-    #   ipv6 = [ "1010:cafe:ffff:fefe::12:10" ];
-    # };
-
     bird = {
       enable = true;
 
-      loopback6 = "1010:cafe:ffff:fefe::b48d";
+      loopback6 = kittenLib.network.internal6.cafe.kittens.loopbacks.vultr;
 
       transitInterfaces = [iface];
       static6 =
         [
-          "1010:cafe:ffff:fefe::b00b/128 unreachable" # Special Anycast "loopback" for default gateways
+          "${kittenLib.network.internal6.cafe.kittens.loopbacks.internet}/128 unreachable" # Special Anycast "loopback" for default gateways
 
           # "2a13:79c0:ffff::/48 unreachable" # Networking stuff
-          # "1010:cafe:ffff:fefe::/64 unreachable" # LoopBacks
           # "2a12:5844:1310::/44 unreachable" # full range /40
           "2a12:5844:1310::/44 unreachable" # New range /44
         ]
@@ -132,18 +126,10 @@ in {
       forward = {
         enable = true;
         keepInvalidState = true;
-        # rules = ''
-        #   # iifname "''${kittenIFACE}" ip6 saddr 1010:cafe:ffff:feff:b00b:caca:b173:0/112 oifname $wireguardIFACEs counter accept
-        #   iifname $wireguardIFACEs ip6 daddr 1010:cafe:ffff:fefe::113:91 tcp dport { 179, 1790 } counter accept
-        #   oifname bootstrap ip6 daddr 1010:cafe:ffff:feff:b00b:3965:222:0/112 counter accept
-
-        #   ip6 saddr 2a01:cb08:bbb:3700::/64 oifname ens19 counter accept
-
-        #   iifname ens19 oifname $wireguardIFACEs counter accept
-        # '';
+        # rules = '' ... '';
         natRules = ''
-          oifname "${iface}" ip6 saddr 1010:cafe:ffff:feff::/64 snat ip6 prefix to 2a12:5844:1311:feff::/64
-          oifname "${iface}" ip6 saddr 1010:cafe:ffff:fefe::/64 snat ip6 prefix to 2a12:5844:1311:fefe::/64
+          oifname "${iface}" ip6 saddr ${kittenLib.network.internal6.cafe.kittens.loopbacks.net} snat ip6 prefix to 2a12:5844:1311:feff::/64
+          oifname "${iface}" ip6 saddr ${kittenLib.network.internal6.cafe.kittens.loopbacks.net} snat ip6 prefix to 2a12:5844:1311:fefe::/64
         '';
       };
     };

--- a/systems/routers/vultr-kit-edge/peers/KIT-IG1-RTR.nix
+++ b/systems/routers/vultr-kit-edge/peers/KIT-IG1-RTR.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/routers/vultr-kit-edge/peers/KIT-virtua-edge.nix
+++ b/systems/routers/vultr-kit-edge/peers/KIT-virtua-edge.nix
@@ -1,4 +1,4 @@
-{...}: let
+{kittenLib, ...}: let
   kittenASN = 4242421945;
 in {
   peerAS = kittenASN;

--- a/systems/stonkmembers/poubelle00/configuration.nix
+++ b/systems/stonkmembers/poubelle00/configuration.nix
@@ -5,6 +5,7 @@
   config,
   targetConfig,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: {

--- a/systems/stonkmembers/prodesk/configuration.nix
+++ b/systems/stonkmembers/prodesk/configuration.nix
@@ -5,6 +5,7 @@
   config,
   targetConfig,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: {

--- a/systems/stonkmembers/stonkstation/configuration.nix
+++ b/systems/stonkmembers/stonkstation/configuration.nix
@@ -5,6 +5,7 @@
   config,
   targetConfig,
   lib,
+  kittenLib,
   pkgs,
   ...
 }: {


### PR DESCRIPTION
nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks "faf0" 
"1010:cafe:ffff:fefe::faf0"

nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks "faf0/"
"1010:cafe:ffff:fefe::faf0/64"

nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks "faf0/"
"1010:cafe:ffff:fefe::faf0/64"

nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks "faf0"  
"1010:cafe:ffff:fefe::faf0"

nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks (-1234) 
"1010:cafe:ffff:fefe::4d2/64"

nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks (1234)  
"1010:cafe:ffff:fefe::4d2"

nix-repl> inputs.kittenLib.network.internal6.cafe.kittens.loopbacks (-1234)
"1010:cafe:ffff:fefe::4d2/64"



example usage
