### PR TITLE
Update Nix build workflow to use cachix actions

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -30,12 +30,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-        # with: 
-        #   install_url: https://install.lix.systems/lix
-        #   install_options: install --no-confirm
-        # 
+      - uses: cachix/install-nix-action@v25
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -49,11 +44,12 @@ jobs:
       artifact: ${{steps.upload.outputs.artifact_id}}
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-        # with: 
-        #   install_url: https://install.lix.systems/lix
-        #   install_options: install --no-confirm
+      - uses: cachix/install-nix-action@v25
+      - uses: cachix/cachix-action@v14
+        with:
+          name: kittenconfigs
+          # If you chose API tokens for write access OR if you have a private cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       
       - id: build-all-nix
         name: Build Nix packages
@@ -82,8 +78,12 @@ jobs:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v25
+      - uses: cachix/cachix-action@v14
+        with:
+          name: kittenconfigs
+          # If you chose API tokens for write access OR if you have a private cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         # with:
         #   install_url: https://install.lix.systems/lix
         #   install_options: install --no-confirm
@@ -150,8 +150,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v25
+      - uses: cachix/cachix-action@v14
+        with:
+          name: kittenconfigs
+          # If you chose API tokens for write access OR if you have a private cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Setup Pages
         uses: actions/configure-pages@v5
         

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -30,7 +30,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31.10.4
         # with: 
         #   install_url: https://install.lix.systems/lix
         #   install_options: install --no-confirm
@@ -47,11 +47,11 @@ jobs:
       artifact: ${{steps.upload.outputs.artifact_id}}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31.10.4
         # with: 
         #   install_url: https://install.lix.systems/lix
         #   install_options: install --no-confirm
-      - uses: cachix/cachix-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: kittenconfigs
           # If you chose API tokens for write access OR if you have a private cache
@@ -84,11 +84,11 @@ jobs:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31.10.4
         # with: 
         #   install_url: https://install.lix.systems/lix
         #   install_options: install --no-confirm
-      - uses: cachix/cachix-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: kittenconfigs
           # If you chose API tokens for write access OR if you have a private cache
@@ -159,11 +159,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31.10.4
         # with: 
         #   install_url: https://install.lix.systems/lix
         #   install_options: install --no-confirm
-      - uses: cachix/cachix-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: kittenconfigs
           # If you chose API tokens for write access OR if you have a private cache

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
-        with: 
-          install_url: https://install.lix.systems/lix
-          install_options: install --no-confirm
+        # with: 
+        #   install_url: https://install.lix.systems/lix
+        #   install_options: install --no-confirm
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -48,9 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
-        with: 
-          install_url: https://install.lix.systems/lix
-          install_options: install --no-confirm
+        # with: 
+        #   install_url: https://install.lix.systems/lix
+        #   install_options: install --no-confirm
       - uses: cachix/cachix-action@v14
         with:
           name: kittenconfigs
@@ -85,9 +85,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
-        with: 
-          install_url: https://install.lix.systems/lix
-          install_options: install --no-confirm
+        # with: 
+        #   install_url: https://install.lix.systems/lix
+        #   install_options: install --no-confirm
       - uses: cachix/cachix-action@v14
         with:
           name: kittenconfigs
@@ -160,9 +160,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
-        with: 
-          install_url: https://install.lix.systems/lix
-          install_options: install --no-confirm
+        # with: 
+        #   install_url: https://install.lix.systems/lix
+        #   install_options: install --no-confirm
       - uses: cachix/cachix-action@v14
         with:
           name: kittenconfigs

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
+        with: 
+          install_url: https://install.lix.systems/lix
+          install_options: install --no-confirm
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -45,6 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
+        with: 
+          install_url: https://install.lix.systems/lix
+          install_options: install --no-confirm
       - uses: cachix/cachix-action@v14
         with:
           name: kittenconfigs
@@ -79,6 +85,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
+        with: 
+          install_url: https://install.lix.systems/lix
+          install_options: install --no-confirm
       - uses: cachix/cachix-action@v14
         with:
           name: kittenconfigs
@@ -151,6 +160,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
+        with: 
+          install_url: https://install.lix.systems/lix
+          install_options: install --no-confirm
       - uses: cachix/cachix-action@v14
         with:
           name: kittenconfigs

--- a/default.nix
+++ b/default.nix
@@ -33,8 +33,9 @@ in
     inputs = {
       inherit pkgs lib;
 
-      sources = let
-        selfSource = builtins.fetchGit ./.;
+    sources =
+      let
+        selfSource = builtins.fetchGit { url = ./.; shallow = true; };
       in
         sources
         // {


### PR DESCRIPTION
Replaced DeterminateSystems actions with cachix actions for Nix installation and caching.