### PR TITLE
fix: peers disabling only disables them inside bird

### DIFF
--- a/modules/system/kitten/connect/bird2/default.nix
+++ b/modules/system/kitten/connect/bird2/default.nix
@@ -185,7 +185,7 @@ in
       lib.mapAttrs' (
         n: v:
         lib.nameValuePair "peers/${n}.conf" {
-          inherit (v) enable;
+          # inherit (v) enable;
           text = ''
             # ${n}
             ${peerFunc (mkPeersFuncArgs n v)}


### PR DESCRIPTION
peers disabling only disables them inside bird files are still loaded